### PR TITLE
Fixing Silent Sign-in timed out

### DIFF
--- a/src/IFrameController.js
+++ b/src/IFrameController.js
@@ -21,7 +21,7 @@ class IFrameController {
 		return new Promise((resolve, reject) => {
 			const timer = setInterval(() => {
 				reject(new IFrameError('Silent sign-in timed out'));
-			}, 5 * 1000);
+			}, 10 * 1000);
 			window.addEventListener('message', (message) => {
 				if (!message.data || message.data.type !== messageType) {
 					return;

--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ class AppID {
 	 * Sign in will be successful only if the user has previously signed in using Cloud Directory and their session is not expired.
 	 * @returns {Promise<Tokens>} The tokens of the authenticated user.
 	 * @throws {OAuthError} Any errors from the server according to the [OAuth spec]{@link https://tools.ietf.org/html/rfc6749#section-4.1.2.1}. e.g. {error: 'access_denied', description: 'User not signed in'}
-	 * @throws {IFrameError} "Silent sign-in timed out" - The iframe will close after 5 seconds if authentication could not be completed.
+	 * @throws {IFrameError} "Silent sign-in timed out" - The iframe will close after 10 seconds if authentication could not be completed.
 	 * @throws {TokenError} Any token validation error.
 	 * @throws {RequestError} Any errors during a HTTP request.
 	 * @example


### PR DESCRIPTION
Fixing Silent Sign-in timed out. Increasing the time we wait to get the authorization response.