### PR TITLE
Update dry-publish.js to use Node v20

### DIFF
--- a/.github/workflows/dry-publish.js.yml
+++ b/.github/workflows/dry-publish.js.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x]
     if: ${{ github.ref == 'refs/heads/master' }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Update dry-publish.js to use Node v20 as this is the minimum version required by Semantic Release.